### PR TITLE
Multi-page editor support

### DIFF
--- a/nodemodeloutline/de.libutzki.xtext.nodemodeloutline.ui/src/de/libutzki/xtext/nodemodeloutline/ui/view/NodeModelOutline.java
+++ b/nodemodeloutline/de.libutzki.xtext.nodemodeloutline.ui/src/de/libutzki/xtext/nodemodeloutline/ui/view/NodeModelOutline.java
@@ -20,7 +20,7 @@ public class NodeModelOutline extends PageBookView {
 
 	@Inject
 	private Provider<IContentOutlinePage> outlinePageProvider;
-	
+
 	@Override
 	protected IPage createDefaultPage(PageBook book) {
         MessagePage page = new MessagePage();
@@ -34,23 +34,20 @@ public class NodeModelOutline extends PageBookView {
 	protected PageRec doCreatePage(IWorkbenchPart part) {
 		IContentOutlinePage nodeModelOutlinePage = createOutlinePage(part);
 		if (nodeModelOutlinePage instanceof IPageBookViewPage) {
-			initPage((IPageBookViewPage)nodeModelOutlinePage);		
+			initPage((IPageBookViewPage)nodeModelOutlinePage);
 		}
 		nodeModelOutlinePage.createControl(getPageBook());
 		return new PageRec(part, nodeModelOutlinePage);
 
 	}
-	
+
 	private IContentOutlinePage createOutlinePage(IWorkbenchPart part)  {
 		IContentOutlinePage page = null;
 		if (outlinePageProvider != null) {
 			// can be null, optional injection
 			page = outlinePageProvider.get();
-			XtextEditor xtextEditor = null;
-			if (part instanceof XtextEditor) {
-				xtextEditor = (XtextEditor)part;
-			}
-			
+			final XtextEditor xtextEditor = part.getAdapter(XtextEditor.class);
+
 			if (xtextEditor != null && page != null) {
 				if (page instanceof ISourceViewerAware) {
 					((ISourceViewerAware) page).setSourceViewer(xtextEditor.getInternalSourceViewer());
@@ -81,7 +78,8 @@ public class NodeModelOutline extends PageBookView {
 
 	@Override
 	protected boolean isImportant(IWorkbenchPart part) {
-        return (part instanceof XtextEditor);
+        XtextEditor editor = part.getAdapter(XtextEditor.class);
+        return editor != null;
 	}
 
 }

--- a/semanticmodeloutline/de.libutzki.xtext.semanticmodeloutline.ui/src/de/libutzki/xtext/semanticmodeloutline/ui/view/SemanticModelOutline.java
+++ b/semanticmodeloutline/de.libutzki.xtext.semanticmodeloutline.ui/src/de/libutzki/xtext/semanticmodeloutline/ui/view/SemanticModelOutline.java
@@ -20,7 +20,7 @@ public class SemanticModelOutline extends PageBookView {
 
 	@Inject
 	private Provider<IContentOutlinePage> outlinePageProvider;
-	
+
 	@Override
 	protected IPage createDefaultPage(PageBook book) {
         MessagePage page = new MessagePage();
@@ -34,23 +34,20 @@ public class SemanticModelOutline extends PageBookView {
 	protected PageRec doCreatePage(IWorkbenchPart part) {
 		IContentOutlinePage nodeModelOutlinePage = createOutlinePage(part);
 		if (nodeModelOutlinePage instanceof IPageBookViewPage) {
-			initPage((IPageBookViewPage)nodeModelOutlinePage);		
+			initPage((IPageBookViewPage)nodeModelOutlinePage);
 		}
 		nodeModelOutlinePage.createControl(getPageBook());
 		return new PageRec(part, nodeModelOutlinePage);
 
 	}
-	
+
 	private IContentOutlinePage createOutlinePage(IWorkbenchPart part)  {
 		IContentOutlinePage page = null;
 		if (outlinePageProvider != null) {
 			// can be null, optional injection
 			page = outlinePageProvider.get();
-			XtextEditor xtextEditor = null;
-			if (part instanceof XtextEditor) {
-				xtextEditor = (XtextEditor)part;
-			}
-			
+			final XtextEditor xtextEditor = part.getAdapter(XtextEditor.class);
+
 			if (xtextEditor != null && page != null) {
 				if (page instanceof ISourceViewerAware) {
 					((ISourceViewerAware) page).setSourceViewer(xtextEditor.getInternalSourceViewer());
@@ -81,7 +78,8 @@ public class SemanticModelOutline extends PageBookView {
 
 	@Override
 	protected boolean isImportant(IWorkbenchPart part) {
-        return (part instanceof XtextEditor);
+        XtextEditor editor = part.getAdapter(XtextEditor.class);
+        return editor != null;
 	}
 
 }


### PR DESCRIPTION
## Problem

If XText editor opened in multi-page editor the semantic and node model views don't react on selection of such part.

## Solution

Correct way to get instance of the XText editor is to use adapter mechanism in Eclipse platform.